### PR TITLE
Remove gulp script from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - "0.11"
   - "0.10"
-script: gulp


### PR DESCRIPTION
It would be finished during prepublish stage anyway, so there is no need to do it twice
