### PR TITLE
Add support of auth tokens for streams

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,9 @@ module.exports = function (opts) {
     rejectUnauthorized: {
       value: opts.rejectUnauthorized
     },
+    cacheStream: {
+      value: true
+    },
 
     url: {
       get: function () {

--- a/lib/mixins/streamable.js
+++ b/lib/mixins/streamable.js
@@ -11,9 +11,15 @@ var Streamable = {
   listen: {
     value: function () {
       return new Promise(function (resolve, reject) {
-        var source;
+        var source
+          , url = this.url;
+
+        if (this.token) {
+          url = url + '?x-auth-token=' + this.token.token;
+        }
+
         try {
-          source = _source = _source || new EventSource(this.url);
+          source = _source = this.cacheStream && _source || new EventSource(url);
         } catch (e) {
           return reject(e);
         }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "eventsource": "^0.1.4",
     "lodash": "^2.4.1",
     "object.assign": "^1.0.1",
-    "rsvp": "^3.0.14"
+    "rsvp": "3.0.14"
   },
   "devDependencies": {
     "browserify": "^6.3.2",

--- a/tests/opts.js
+++ b/tests/opts.js
@@ -15,6 +15,9 @@ module.exports = {
   api_version: {
     value: 'v1'
   },
+  cacheStream: {
+    value: true
+  },
 
   url: {
     get: function () {


### PR DESCRIPTION
Browser implementation of EventSource does not allow you to define custom headers so we need to pass auth token some other way. For example, as query parameter.

Also:
 - add private config variable to disable caching eventsource instance for testing purposes