### PR TITLE
Support authentication for integration tests

### DIFF
--- a/integration/config.js
+++ b/integration/config.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = {
+  rejectUnauthorized: false,
+  credentials: {
+    user: 'test',
+    password: 'test'
+  }
+};

--- a/integration/test-actions.js
+++ b/integration/test-actions.js
@@ -6,21 +6,20 @@ var _ = require('lodash')
   , chai = require('chai')
   , chaiAsPromised = require("chai-as-promised")
   , rsvp = require('rsvp')
+  , config = require('./config.js')
   ;
 
 chai.use(chaiAsPromised);
 
 var all = rsvp.all
   , expect = chai.expect
-  , st2client = require('../index')({
-    rejectUnauthorized: false
-  })
+  , st2client = require('../index')(config)
   ;
 
 var MINIMUM_ENTITIES = 3;
 
 describe('Actions', function () {
-  var auth = st2client.authenticate('test', 'test');
+  var auth = st2client.authenticate(config.credentials.user, config.credentials.password);
 
   describe('#list()', function () {
     it('should return a promise of a list of actions', function () {

--- a/integration/test-auth.js
+++ b/integration/test-auth.js
@@ -5,15 +5,14 @@ var _ = require('lodash')
   , chai = require('chai')
   , chaiAsPromised = require("chai-as-promised")
   , rsvp = require('rsvp')
+  , config = require('./config.js')
   ;
 
 chai.use(chaiAsPromised);
 
 var all = rsvp.all
   , expect = chai.expect
-  , st2client = require('../index')({
-    rejectUnauthorized: false
-  })
+  , st2client = require('../index')(config)
   ;
 
 describe('Auth', function () {
@@ -22,14 +21,14 @@ describe('Auth', function () {
     // Apache takes a lot of time to spin up so the test may fail by timeout. Increase timeout or
     // run it multiple times.
     it('should return a promise of a token', function () {
-      var result = st2client.auth.authenticate('test', 'test');
+      var result = st2client.authenticate(config.credentials.user, config.credentials.password);
 
       return all([
         expect(result).to.be.fulfilled,
         expect(result).to.eventually.be.an('object'),
         result.then(function (token) {
           expect(token).to.have.property('id');
-          expect(token).to.have.property('user', 'test');
+          expect(token).to.have.property('user', config.credentials.user);
           expect(token).to.have.property('token');
           expect(token).to.have.property('expiry');
         })

--- a/integration/test-history.js
+++ b/integration/test-history.js
@@ -5,21 +5,20 @@ var _ = require('lodash')
   , chai = require('chai')
   , chaiAsPromised = require("chai-as-promised")
   , rsvp = require('rsvp')
+  , config = require('./config.js')
   ;
 
 chai.use(chaiAsPromised);
 
 var all = rsvp.all
   , expect = chai.expect
-  , st2client = require('../index')({
-    rejectUnauthorized: false
-  })
+  , st2client = require('../index')(config)
   ;
 
 var MINIMUM_ENTITIES = 3;
 
 describe('History', function () {
-  var auth = st2client.authenticate('test', 'test');
+  var auth = st2client.authenticate(config.credentials.user, config.credentials.password);
 
   describe('#list()', function () {
     it('should return a promise of a list of history records', function () {

--- a/integration/test-stream.js
+++ b/integration/test-stream.js
@@ -5,6 +5,7 @@ var chai = require('chai')
   , chaiAsPromised = require("chai-as-promised")
   , rsvp = require('rsvp')
   , EventSource = global.EventSource || require('eventsource')
+  , config = require('./config.js')
   ;
 
 chai.use(chaiAsPromised);
@@ -12,37 +13,34 @@ chai.use(chaiAsPromised);
 var all = rsvp.all
   , expect = chai.expect
   , Promise = rsvp.Promise
-  , st2client = require('../index')({
-    rejectUnauthorized: false
-  })
+  , st2client = require('../index')(config)
   ;
 
 describe('Stream', function () {
-  //var auth = st2client.authenticate('test', 'test');
+  var auth = st2client.authenticate(config.credentials.user, config.credentials.password);
 
   describe('#listen()', function () {
     it('should return a promise of an event source', function () {
-      // var result = auth.then(function () {
-      //   return st2client.stream.listen();
-      // });
-
-      var result = st2client.stream.listen();
+      var listen = auth.then(function () {
+        return st2client.stream.listen();
+      });
 
       return all([
-        expect(result).to.be.fulfilled,
-        result.then(function (source) {
+        expect(listen).to.be.fulfilled,
+        listen.then(function (source) {
           expect(source).to.be.instanceOf(EventSource);
         })
       ]);
     });
 
     it('should return the same event source', function () {
-      // var result = auth.then(function () {
-      //   return st2client.stream.listen();
-      // });
 
-      var result1 = st2client.stream.listen()
-        , result2 = st2client.stream.listen();
+      var result1 = auth.then(function () {
+          return st2client.stream.listen();
+        })
+        , result2 = auth.then(function () {
+          return st2client.stream.listen();
+        });
 
       return all([
         expect(result1).to.be.fulfilled,
@@ -56,8 +54,11 @@ describe('Stream', function () {
     });
 
     it('should notify about creation of ActionExecution', function () {
+      var listen = auth.then(function () {
+        return st2client.stream.listen();
+      });
 
-      return st2client.stream.listen().then(function (stream) {
+      return listen.then(function (stream) {
         var eventName = "st2.actionexecution__create";
         var payload = {
           action: 'core.local',
@@ -67,8 +68,18 @@ describe('Stream', function () {
         };
 
         var response = new Promise(function (resolve, reject) {
+          var resolver = function (event) {
+            request.then(function (execution) {
+              var data = JSON.parse(event.data);
+
+              if (execution.id === data.id) {
+                resolve(event);
+              }
+            });
+          };
+
           stream.onerror = reject;
-          stream.addEventListener(eventName, resolve);
+          stream.addEventListener(eventName, resolver);
         }).then(function (event) {
           expect(event).to.have.property('type', eventName);
           expect(event).to.have.property('data');
@@ -77,6 +88,8 @@ describe('Stream', function () {
           var data = JSON.parse(event.data);
           expect(data).to.have.property('action', payload.action);
           expect(data.parameters).to.be.deep.equal(payload.parameters);
+        }).finally(function () {
+          stream.removeAllListeners(eventName);
         });
 
         var request = st2client.actionExecutions.create(payload);
@@ -87,8 +100,11 @@ describe('Stream', function () {
     });
 
     it('should notify about updates during ActionExecution', function () {
+      var listen = auth.then(function () {
+        return st2client.stream.listen();
+      });
 
-      return st2client.stream.listen().then(function (stream) {
+      return listen.then(function (stream) {
         var eventName = "st2.actionexecution__update";
         var payload = {
           action: 'core.local',
@@ -98,8 +114,18 @@ describe('Stream', function () {
         };
 
         var response = new Promise(function (resolve, reject) {
+          var resolver = function (event) {
+            request.then(function (execution) {
+              var data = JSON.parse(event.data);
+
+              if (execution.id === data.id) {
+                resolve(event);
+              }
+            });
+          };
+
           stream.onerror = reject;
-          stream.addEventListener(eventName, resolve);
+          stream.addEventListener(eventName, resolver);
         }).then(function (event) {
           expect(event).to.have.property('type', eventName);
           expect(event).to.have.property('data');
@@ -108,6 +134,8 @@ describe('Stream', function () {
           var data = JSON.parse(event.data);
           expect(data).to.have.property('action', payload.action);
           expect(data.parameters).to.be.deep.equal(payload.parameters);
+        }).finally(function () {
+          stream.removeAllListeners(eventName);
         });
 
         var request = st2client.actionExecutions.create(payload);
@@ -118,6 +146,14 @@ describe('Stream', function () {
     });
 
 
+  });
+
+  after(function () {
+    auth.then(function () {
+      return st2client.stream.listen();
+    }).then(function (stream) {
+      stream.close();
+    });
   });
 
 });

--- a/lib/mixins/streamable.js
+++ b/lib/mixins/streamable.js
@@ -14,7 +14,7 @@ var Streamable = {
         var source
           , url = this.url;
 
-        if (this.token) {
+        if (this.token && this.token.token) {
           url = url + '?x-auth-token=' + this.token.token;
         }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -44,7 +44,9 @@ var request = function (params, body) {
         });
 
         res.on('end', function () {
-          if ((res.headers['content-type'] || []).indexOf('application/json') !== -1) {
+          var contentType = res.headers && res.headers['content-type'] || [];
+
+          if (contentType.indexOf('application/json') !== -1) {
             try {
               res.body = JSON.parse(res.body);
             } catch (e) {


### PR DESCRIPTION
Also:
 - check entity id in stream tests to avoid false negatives due to side effects from another test
 - close stream after all tests are finished