### PR TITLE
Make sure url always starts with the root of the path

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = function (opts) {
           protocol: this.protocol,
           hostname: this.host,
           port: this.port,
-          pathname: [this.api_version, this.path].join('')
+          pathname: ['/', this.api_version, this.path].join('')
         });
       }
     }

--- a/tests/opts.js
+++ b/tests/opts.js
@@ -4,13 +4,13 @@ var url = require('url');
 
 module.exports = {
   host: {
-    value: 'test'
+    value: undefined
   },
   auth: {
     value: {}
   },
   port: {
-    value: 9101
+    value: undefined
   },
   api_version: {
     value: 'v1'
@@ -25,7 +25,7 @@ module.exports = {
         protocol: this.protocol,
         hostname: this.host,
         port: this.port,
-        pathname: [this.api_version, this.path].join('')
+        pathname: ['/', this.api_version, this.path].join('')
       });
     }
   }

--- a/tests/test-authenticatable.js
+++ b/tests/test-authenticatable.js
@@ -15,7 +15,7 @@ nock.disableNetConnect();
 var all = rsvp.all
   , expect = chai.expect
   , Authenticatable = require('../lib/mixins/authenticatable')
-  , mock = nock('http://test:9100', {
+  , mock = nock('http://localhost:9100', {
     reqheaders: {
       'content-type': 'application/json'
     }

--- a/tests/test-deletable.js
+++ b/tests/test-deletable.js
@@ -15,7 +15,7 @@ nock.disableNetConnect();
 var all = rsvp.all
   , expect = chai.expect
   , Deletable = require('../lib/mixins/deletable')
-  , mock = nock('http://test:9101')
+  , mock = nock('http://localhost')
   ;
 
 describe('Deletable', function () {

--- a/tests/test-editable.js
+++ b/tests/test-editable.js
@@ -15,7 +15,7 @@ nock.disableNetConnect();
 var all = rsvp.all
   , expect = chai.expect
   , Editable = require('../lib/mixins/editable')
-  , mock = nock('http://test:9101', {
+  , mock = nock('http://localhost', {
     reqheaders: {
       'content-type': 'application/json'
     }

--- a/tests/test-enumerable.js
+++ b/tests/test-enumerable.js
@@ -16,7 +16,7 @@ nock.disableNetConnect();
 var all = rsvp.all
   , expect = chai.expect
   , Enumerable = require('../lib/mixins/enumerable')
-  , mock = nock('http://test:9101')
+  , mock = nock('http://localhost')
   ;
 
 describe('Enumerable', function () {

--- a/tests/test-paginatable.js
+++ b/tests/test-paginatable.js
@@ -16,7 +16,7 @@ nock.disableNetConnect();
 var all = rsvp.all
   , expect = chai.expect
   , Paginatable = require('../lib/mixins/paginatable')
-  , mock = nock('http://test:9101')
+  , mock = nock('http://localhost')
   ;
 
 describe('Paginatable', function () {

--- a/tests/test-readable.js
+++ b/tests/test-readable.js
@@ -15,7 +15,7 @@ nock.disableNetConnect();
 var all = rsvp.all
   , expect = chai.expect
   , Readable = require('../lib/mixins/readable')
-  , mock = nock('http://test:9101')
+  , mock = nock('http://localhost')
   ;
 
 describe('Readable', function () {

--- a/tests/test-streamable.js
+++ b/tests/test-streamable.js
@@ -31,7 +31,7 @@ nock.disableNetConnect();
 var all = rsvp.all
   , expect = chai.expect
   , Streamable = require('../lib/mixins/streamable')
-  , mock = nock('http://test:9101')
+  , mock = nock('http://localhost')
   ;
 
 describe('Streamable', function () {
@@ -53,7 +53,7 @@ describe('Streamable', function () {
         expect(result).to.be.fulfilled,
         result.then(function (source) {
           expect(source).to.be.instanceOf(EventSource);
-          expect(source).to.have.property('url', '//test:9101/v1/stream');
+          expect(source).to.have.property('url', '/v1/stream');
           source.close();
         })
       ]);
@@ -98,7 +98,7 @@ describe('Streamable', function () {
         expect(result).to.be.fulfilled,
         result.then(function (source) {
           expect(source).to.be.instanceOf(EventSource);
-          expect(source).to.have.property('url', '//test:9101/v1/stream?x-auth-token=DEADBEEF');
+          expect(source).to.have.property('url', '/v1/stream?x-auth-token=DEADBEEF');
           source.close();
         })
       ]);

--- a/tests/test-writable.js
+++ b/tests/test-writable.js
@@ -15,7 +15,7 @@ nock.disableNetConnect();
 var all = rsvp.all
   , expect = chai.expect
   , Writable = require('../lib/mixins/writable')
-  , mock = nock('http://test:9101', {
+  , mock = nock('http://localhost', {
     reqheaders: {
       'content-type': 'application/json'
     }


### PR DESCRIPTION
Also, rewrite all tests to work with relative path instead of absolute.