### PR TITLE
Fix compatiblity with previous versions of st2client

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,9 +18,9 @@ var _ = require('lodash')
   ;
 
 module.exports = function (opts) {
-  opts = _.assign({
+  opts = _.defaults({}, opts, {
     token: {}
-  }, opts);
+  });
 
   var Opts = {
     protocol: {

--- a/tests/test-index.js
+++ b/tests/test-index.js
@@ -1,3 +1,4 @@
+/*jshint -W030*/
 /*global Promise:true, describe, it*/
 'use strict';
 
@@ -45,6 +46,24 @@ describe('Index', function () {
     index.setToken({ token: 'DEADBEEF' });
 
     expect(opts.token).to.be.equal(undefined);
+  });
+
+  it('should accept token being declared', function () {
+    var Index = require('../index');
+    var opts = { token: { token: 'some' } };
+
+    var index = Index(opts);
+
+    expect(index.token).to.be.deep.equal(opts.token);
+  });
+
+  it('should accept token being declared by undefined', function () {
+    var Index = require('../index');
+    var opts = { token: undefined };
+
+    var index = Index(opts);
+
+    expect(index.token).to.be.an('object').and.empty;
   });
 
   describe('#setToken()', function () {


### PR DESCRIPTION
Latest changes in factory method broke auth in st2web. This commit fixes that. Version 0.3.6 is deprecated.