### PR TITLE
Remove default port for authentication

### DIFF
--- a/lib/mixins/authenticatable.js
+++ b/lib/mixins/authenticatable.js
@@ -37,7 +37,7 @@ var Authenticatable = {
         method: 'post',
         protocol: this.auth.protocol || this.protocol,
         host: this.auth.host || this.host,
-        port: this.auth.port || 9100,
+        port: this.auth.port,
         prefix: this.auth.prefix,
         version: null,
         headers: {

--- a/tests/test-authenticatable.js
+++ b/tests/test-authenticatable.js
@@ -13,7 +13,7 @@ nock.disableNetConnect();
 
 var expect = chai.expect
   , Authenticatable = require('../lib/mixins/authenticatable')
-  , mock = nock('http://localhost:9100', {
+  , mock = nock('http://localhost', {
     reqheaders: {
       'content-type': 'application/x-www-form-urlencoded'
     }
@@ -121,7 +121,7 @@ describe('Authenticatable', function () {
         }
       }, Authenticatable).value;
 
-      nock('https://localhost:9100').post('/tokens')
+      nock('https://localhost').post('/tokens')
         .reply(201);
 
       var result = api.authenticate('stanley', 'rocks');


### PR DESCRIPTION
We’ve deprecated calling st2auth directly for quite some time ago. By that point, all backward compatibility assurances have expired and I doubt it will affect a single user.