### PR TITLE
Remove auth tokens from query params and allow redefine Stream url

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,6 +93,9 @@ module.exports = function (opts) {
     cacheStream: {
       value: true
     },
+    noQueryTokens: {
+      value: opts.noQueryTokens || false
+    },
 
     url: {
       get: function () {

--- a/index.js
+++ b/index.js
@@ -58,6 +58,19 @@ module.exports = function (opts) {
     };
   }
 
+  if (opts.stream && typeof opts.stream === 'string') {
+    var pStream = url.parse(opts.stream);
+
+    pStream.protocol = pStream.protocol && pStream.protocol.slice(0, -1);
+
+    opts.stream = {
+      protocol: pStream.protocol,
+      host: pStream.hostname,
+      port: pStream.port || protoPorts[pStream.protocol || 'http'],
+      prefix: pStream.path
+    };
+  }
+
   var Opts = {
     protocol: {
       value: opts.protocol
@@ -76,6 +89,9 @@ module.exports = function (opts) {
     },
     auth: {
       value: opts.auth || {}
+    },
+    stream: {
+      value: opts.stream || {}
     },
     token: {
       get: function () {

--- a/integration/config.js
+++ b/integration/config.js
@@ -3,6 +3,7 @@
 module.exports = {
   api: 'https://192.168.10.40/api',
   auth: 'https://192.168.10.40/auth',
+  stream: 'https://192.168.10.40/stream',
   rejectUnauthorized: false,
   credentials: {
     user: 'admin',

--- a/lib/mixins/routable.js
+++ b/lib/mixins/routable.js
@@ -12,7 +12,7 @@ var Routable = {
 
       query = query || {};
 
-      if (this.token && this.token.token) {
+      if (!this.noQueryTokens && this.token && this.token.token) {
         query['x-auth-token'] = this.token.token;
       }
 

--- a/lib/mixins/streamable.js
+++ b/lib/mixins/streamable.js
@@ -15,14 +15,14 @@ var Streamable = {
 
         var query = [];
 
-        if (this.token.token) {
+        if (!this.noQueryTokens && this.token.token) {
           query.push({
             key: 'x-auth-token',
             value: this.token.token
           });
         }
 
-        if (this.key.key) {
+        if (!this.noQueryTokens && this.key.key) {
           query.push({
             key: 'st2-api-key',
             value: this.key.key

--- a/lib/mixins/streamable.js
+++ b/lib/mixins/streamable.js
@@ -2,16 +2,42 @@
 'use strict';
 
 var EventSource = global.EventSource || require('eventsource')
+  , url = require('url')
   ;
 
 var _source;
 
 var Streamable = {
+  url: {
+    get: function () {
+      var prefix = '';
+      if (this.prefix) {
+        prefix = this.stream.prefix || this.prefix;
+        if (prefix[0] !== '/') {
+          prefix = '/' + prefix;
+        }
+        if (prefix[prefix.length - 1] === '/') {
+          prefix = prefix.slice(0, -1);
+        }
+      }
+      if (this.api_version) {
+        prefix += '/' + this.api_version;
+      }
+
+      return url.format({
+        protocol: this.stream.protocol || this.protocol,
+        hostname: this.stream.host || this.host,
+        port: this.stream.port || this.port,
+        pathname: prefix + this.path
+      });
+    }
+  },
+
   listen: {
     value: function () {
       return new Promise(function (resolve, reject) {
         var source
-          , url = this.url;
+          , streamUrl = this.url;
 
         var query = [];
 
@@ -30,14 +56,15 @@ var Streamable = {
         }
 
         if (query.length) {
-          url += '?' + query.map(function (param) {
+          streamUrl += '?' + query.map(function (param) {
             return param.key + '=' + param.value;
           }).join('&');
         }
 
         try {
-          source = _source = this.cacheStream && _source || new EventSource(url, {
-            rejectUnauthorized: this.rejectUnauthorized
+          source = _source = this.cacheStream && _source || new EventSource(streamUrl, {
+            rejectUnauthorized: this.rejectUnauthorized,
+            withCredentials: true
           });
         } catch (e) {
           return reject(e);

--- a/tests/opts.js
+++ b/tests/opts.js
@@ -24,6 +24,9 @@ module.exports = {
   key: {
     value: {}
   },
+  noQueryTokens: {
+    value: false
+  },
 
   url: {
     get: function () {

--- a/tests/opts.js
+++ b/tests/opts.js
@@ -9,6 +9,9 @@ module.exports = {
   auth: {
     value: {}
   },
+  stream: {
+    value: {}
+  },
   port: {
     value: undefined
   },

--- a/tests/test-index.js
+++ b/tests/test-index.js
@@ -69,12 +69,13 @@ describe('Index', function () {
     expect(index.token).to.be.an('object').and.empty;
   });
 
-  it('should parse API and Auth url when defined as string', function () {
+  it('should parse API, Auth and Stream url when defined as string', function () {
     var Index = require('../index');
 
     var client = Index({
       api: 'https://some:9199/query/mo',
-      auth: '/auth'
+      auth: '/auth',
+      stream: '/stream'
     });
 
     expect(client.index.url).to.equal('https://some:9199/query/mo/v1/');
@@ -83,6 +84,12 @@ describe('Index', function () {
       host: null,
       port: 80,
       prefix: '/auth'
+    });
+    expect(client.index.stream).to.deep.equal({
+      protocol: null,
+      host: null,
+      port: 80,
+      prefix: '/stream'
     });
   });
 


### PR DESCRIPTION
Refers to https://github.com/StackStorm/discussions/issues/242

From now on, you can explicitly tell client not to put auth tokens into query strings and instead rely on cookies (which hopefully going to be supported starting ST2 2.4). The `noQueryTokens` option is disabled by default for backwards compatibility and should be used at your own discretion and a level of healthy paranoia.