### PR TITLE
ES5 and update Axios

### DIFF
--- a/lib/mixins/editable.js
+++ b/lib/mixins/editable.js
@@ -33,7 +33,7 @@ var Editable = {
       return this.request({
         method: 'put',
         path: [this.path, id].join('/'),
-        query
+        query: query
       }, payload).then(function (res) {
 
         if (res.statusCode !== 200) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node": ">=0.11.0"
   },
   "dependencies": {
-    "axios": "^0.7.0",
+    "axios": "^0.17.1",
     "eventsource": "^0.1.4",
     "object.assign": "^1.0.1"
   },


### PR DESCRIPTION
In running production tests for st2web, I noticed that there is a tiny bit of es6 that was causing the build to fail.

This also update the `axios` dependency to the latest, in order to be able to use `moxios`.