### PR TITLE
Support pagination for action alias.

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ module.exports = function (opts) {
     auth: endpoint('/tokens', Opts, Authenticatable),
 
     actions: endpoint('/actions', Opts, Readable, Enumerable, Writable, Editable, Deletable),
-    actionAlias: endpoint('/actionalias', Opts, Readable, Enumerable, Writable, Editable, Deletable),
+    actionAlias: endpoint('/actionalias', Opts, Readable, Paginatable, Writable, Editable, Deletable),
     actionOverview: endpoint('/actions/views/overview', Opts, Readable, Enumerable),
     actionEntryPoint: endpoint('/actions/views/entry_point', Opts, Readable),
     aliasExecution: endpoint('/aliasexecution', Opts, Writable),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "st2client",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "StackStorm ST2 API library",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes https://github.com/StackStorm/hubot-stackstorm/issues/158
Change `actionAlias` endpoint to load `Paginatable` instead of `Enumerable` module to support pagination for action alias.