### PR TITLE
Emit st2 token expiry event 10s earlier

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,7 +189,7 @@ module.exports = function (opts) {
           }
           this._expiryTimeout = setTimeout(function () {
             this.emit('expiry', token);
-          }.bind(this), new Date(token.expiry) - new Date());
+          }.bind(this), new Date(token.expiry) - new Date() - 1000);
           return token;
         }.bind(this));
       }

--- a/index.js
+++ b/index.js
@@ -189,7 +189,7 @@ module.exports = function (opts) {
           }
           this._expiryTimeout = setTimeout(function () {
             this.emit('expiry', token);
-          }.bind(this), new Date(token.expiry) - new Date() - 1000);
+          }.bind(this), new Date(token.expiry) - new Date() - 10 * 1000);
           return token;
         }.bind(this));
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "st2client",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "StackStorm ST2 API library",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This allows re-request st2 token in advance, instead of trying to get it when it's _already_ expired.

Add here HTTP request/response time to communicate token update and it leads to issues and races like https://github.com/StackStorm/st2/issues/4119 https://github.com/StackStorm/hubot-stackstorm/pull/178#discussion_r296029876 https://github.com/StackStorm/hubot-stackstorm/issues/157