### PR TITLE
Activate Travis tests and add authentication parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,21 @@
 language: node_js
 node_js:
-  - "4.1"
-  - "4.0"
-  - "0.12"
-  - "0.11"
-  - "iojs"
+  - "6"
+  - "7"
+  - "8"
+  - "9"
+  - "10"
+  - "11"
+  - "12"
+  - "node"
+matrix:
+  # Report status as soon as just the required tests run
+  fast_finish: true
+  allow_failures:
+    # We do not support < 8 or > 10, but we can still test it
+    - node_js: "6"
+    - node_js: "7"
+    - node_js: "11"
+    - node_js: "12"
+    - node_js: node
 sudo: false

--- a/lib/mixins/attributable.js
+++ b/lib/mixins/attributable.js
@@ -2,7 +2,7 @@
 
 var Attributable = {
   attribute: {
-    value: function (id, attribute) {
+    value: function (id, attribute, alt_auth) {
       if (!id) {
         throw {
           name: 'ArgumentError',
@@ -17,10 +17,22 @@ var Attributable = {
         };
       }
 
-      return this.request({
+      var request_opts = {
         method: 'get',
         path: [this.path, id, 'attribute', attribute].join('/')
-      }).then(function (res) {
+      };
+
+      if (alt_auth && alt_auth.token) {
+        request_opts.headers = {
+          'x-auth-token': alt_auth.token
+        };
+      } else if (alt_auth && alt_auth.api_key) {
+        request_opts.headers = {
+          'st2-api-key': alt_auth.api_key
+        };
+      }
+
+      return this.request(request_opts).then(function (res) {
 
         if (res.statusCode >= 400) {
           throw {

--- a/lib/mixins/attributable.js
+++ b/lib/mixins/attributable.js
@@ -1,8 +1,10 @@
 'use strict';
 
+var util = require('./util');
+
 var Attributable = {
   attribute: {
-    value: function (id, attribute, alt_auth) {
+    value: function (id, attribute, altAuth) {
       if (!id) {
         throw {
           name: 'ArgumentError',
@@ -17,22 +19,12 @@ var Attributable = {
         };
       }
 
-      var request_opts = {
+      var requestOpts = util.addAltAuthHeaders({
         method: 'get',
         path: [this.path, id, 'attribute', attribute].join('/')
-      };
+      }, altAuth);
 
-      if (alt_auth && alt_auth.token) {
-        request_opts.headers = {
-          'x-auth-token': alt_auth.token
-        };
-      } else if (alt_auth && alt_auth.api_key) {
-        request_opts.headers = {
-          'st2-api-key': alt_auth.api_key
-        };
-      }
-
-      return this.request(request_opts).then(function (res) {
+      return this.request(requestOpts).then(function (res) {
 
         if (res.statusCode >= 400) {
           throw {

--- a/lib/mixins/deletable.js
+++ b/lib/mixins/deletable.js
@@ -2,7 +2,7 @@
 
 var Deletable = {
   delete: {
-    value: function (id) {
+    value: function (id, alt_auth) {
       if (!id) {
         throw {
           name: 'ArgumentError',
@@ -10,10 +10,22 @@ var Deletable = {
         };
       }
 
-      return this.request({
+      var request_opts = {
         method: 'delete',
         path: [this.path, id].join('/'),
-      }).then(function (res) {
+      };
+
+      if (alt_auth && alt_auth.token) {
+        request_opts.headers = {
+          'x-auth-token': alt_auth.token
+        };
+      } else if (alt_auth && alt_auth.api_key) {
+        request_opts.headers = {
+          'st2-api-key': alt_auth.api_key
+        };
+      }
+
+      return this.request(request_opts).then(function (res) {
 
         if (res.statusCode !== 200 && res.statusCode !== 204) {
           throw {

--- a/lib/mixins/deletable.js
+++ b/lib/mixins/deletable.js
@@ -1,8 +1,10 @@
 'use strict';
 
+var util = require('./util');
+
 var Deletable = {
   delete: {
-    value: function (id, alt_auth) {
+    value: function (id, altAuth) {
       if (!id) {
         throw {
           name: 'ArgumentError',
@@ -10,22 +12,12 @@ var Deletable = {
         };
       }
 
-      var request_opts = {
+      var requestOpts = util.addAltAuthHeaders({
         method: 'delete',
         path: [this.path, id].join('/'),
-      };
+      }, altAuth);
 
-      if (alt_auth && alt_auth.token) {
-        request_opts.headers = {
-          'x-auth-token': alt_auth.token
-        };
-      } else if (alt_auth && alt_auth.api_key) {
-        request_opts.headers = {
-          'st2-api-key': alt_auth.api_key
-        };
-      }
-
-      return this.request(request_opts).then(function (res) {
+      return this.request(requestOpts).then(function (res) {
 
         if (res.statusCode !== 200 && res.statusCode !== 204) {
           throw {

--- a/lib/mixins/editable.js
+++ b/lib/mixins/editable.js
@@ -2,7 +2,7 @@
 
 var Editable = {
   edit: {
-    value: function (id, payload, query) {
+    value: function (id, payload, query, alt_auth) {
       if (!payload) {
         payload = id;
         id = null;
@@ -30,11 +30,23 @@ var Editable = {
         };
       }
 
-      return this.request({
+      var request_opts = {
         method: 'put',
         path: [this.path, id].join('/'),
         query
-      }, payload).then(function (res) {
+      };
+
+      if (alt_auth && alt_auth.token) {
+        request_opts.headers = {
+          'x-auth-token': alt_auth.token
+        };
+      } else if (alt_auth && alt_auth.api_key) {
+        request_opts.headers = {
+          'st2-api-key': alt_auth.api_key
+        };
+      }
+
+      return this.request(request_opts, payload).then(function (res) {
 
         if (res.statusCode !== 200) {
           throw {

--- a/lib/mixins/editable.js
+++ b/lib/mixins/editable.js
@@ -1,8 +1,10 @@
 'use strict';
 
+var util = require('./util');
+
 var Editable = {
   edit: {
-    value: function (id, payload, query, alt_auth) {
+    value: function (id, payload, query, altAuth) {
       if (!payload) {
         payload = id;
         id = null;
@@ -30,23 +32,13 @@ var Editable = {
         };
       }
 
-      var request_opts = {
+      var requestOpts = util.addAltAuthHeaders({
         method: 'put',
         path: [this.path, id].join('/'),
         query
-      };
+      }, altAuth);
 
-      if (alt_auth && alt_auth.token) {
-        request_opts.headers = {
-          'x-auth-token': alt_auth.token
-        };
-      } else if (alt_auth && alt_auth.api_key) {
-        request_opts.headers = {
-          'st2-api-key': alt_auth.api_key
-        };
-      }
-
-      return this.request(request_opts, payload).then(function (res) {
+      return this.request(requestOpts, payload).then(function (res) {
 
         if (res.statusCode !== 200) {
           throw {

--- a/lib/mixins/enumerable.js
+++ b/lib/mixins/enumerable.js
@@ -1,29 +1,21 @@
 'use strict';
 
+var util = require('./util');
+
 var Enumerable = {
   list: {
-    value: function (query, alt_auth) {
-      return this.listAll(query, alt_auth);
+    value: function (query, altAuth) {
+      return this.listAll(query, altAuth);
     }
   },
   listAll: {
-    value: function (query, alt_auth) {
-      var request_opts = {
+    value: function (query, altAuth) {
+      var requestOpts = util.addAltAuthHeaders({
         method: 'get',
         query: query
-      };
+      }, altAuth);
 
-      if (alt_auth && alt_auth.token) {
-        request_opts.headers = {
-          'x-auth-token': alt_auth.token
-        };
-      } else if (alt_auth && alt_auth.api_key) {
-        request_opts.headers = {
-          'st2-api-key': alt_auth.api_key
-        };
-      }
-
-      return this.request(request_opts).then(function (res) {
+      return this.request(requestOpts).then(function (res) {
 
         if (res.statusCode >= 400) {
           throw {

--- a/lib/mixins/enumerable.js
+++ b/lib/mixins/enumerable.js
@@ -2,16 +2,28 @@
 
 var Enumerable = {
   list: {
-    value: function (query) {
-      return this.listAll(query);
+    value: function (query, alt_auth) {
+      return this.listAll(query, alt_auth);
     }
   },
   listAll: {
-    value: function (query) {
-      return this.request({
+    value: function (query, alt_auth) {
+      var request_opts = {
         method: 'get',
         query: query
-      }).then(function (res) {
+      };
+
+      if (alt_auth && alt_auth.token) {
+        request_opts.headers = {
+          'x-auth-token': alt_auth.token
+        };
+      } else if (alt_auth && alt_auth.api_key) {
+        request_opts.headers = {
+          'st2-api-key': alt_auth.api_key
+        };
+      }
+
+      return this.request(request_opts).then(function (res) {
 
         if (res.statusCode >= 400) {
           throw {

--- a/lib/mixins/paginatable.js
+++ b/lib/mixins/paginatable.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var assign = Object.assign || require('object.assign')
+var assign = Object.assign || require('object.assign'),
+  util = require('./util');
   ;
 
 var Paginatable = {
@@ -10,40 +11,30 @@ var Paginatable = {
   },
 
   list: {
-    value: function (query, alt_auth) {
+    value: function (query, altAuth) {
       query = assign({}, query);
 
       var page = query.page;
       delete query.page;
 
-      return this.listPage(page, query, alt_auth);
+      return this.listPage(page, query, altAuth);
     }
   },
 
   listPage: {
-    value: function (page, query, alt_auth) {
+    value: function (page, query, altAuth) {
       query = query || {};
 
-      var request_opts = {
+      var requestOpts = util.addAltAuthHeaders({
         method: 'get',
         query: assign({
           limit: this.limit
         }, query, {
           offset: (page > 1 ? page - 1 : 0) * (query.limit || this.limit)
         })
-      };
+      }, altAuth);
 
-      if (alt_auth && alt_auth.token) {
-        request_opts.headers = {
-          'x-auth-token': alt_auth.token
-        };
-      } else if (alt_auth && alt_auth.api_key) {
-        request_opts.headers = {
-          'st2-api-key': alt_auth.api_key
-        };
-      }
-
-      return this.request(request_opts).then(function (res) {
+      return this.request(requestOpts).then(function (res) {
 
         if (res.statusCode >= 400) {
           throw {

--- a/lib/mixins/paginatable.js
+++ b/lib/mixins/paginatable.js
@@ -10,28 +10,40 @@ var Paginatable = {
   },
 
   list: {
-    value: function (query) {
+    value: function (query, alt_auth) {
       query = assign({}, query);
 
       var page = query.page;
       delete query.page;
 
-      return this.listPage(page, query);
+      return this.listPage(page, query, alt_auth);
     }
   },
 
   listPage: {
-    value: function (page, query) {
+    value: function (page, query, alt_auth) {
       query = query || {};
 
-      return this.request({
+      var request_opts = {
         method: 'get',
         query: assign({
           limit: this.limit
         }, query, {
           offset: (page > 1 ? page - 1 : 0) * (query.limit || this.limit)
         })
-      }).then(function (res) {
+      };
+
+      if (alt_auth && alt_auth.token) {
+        request_opts.headers = {
+          'x-auth-token': alt_auth.token
+        };
+      } else if (alt_auth && alt_auth.api_key) {
+        request_opts.headers = {
+          'st2-api-key': alt_auth.api_key
+        };
+      }
+
+      return this.request(request_opts).then(function (res) {
 
         if (res.statusCode >= 400) {
           throw {

--- a/lib/mixins/readable.js
+++ b/lib/mixins/readable.js
@@ -1,8 +1,10 @@
 'use strict';
 
+var util = require('./util');
+
 var Readable = {
   get: {
-    value: function (id, query, alt_auth) {
+    value: function (id, query, altAuth) {
       if (!id) {
         throw {
           name: 'ArgumentError',
@@ -10,23 +12,13 @@ var Readable = {
         };
       }
 
-      var request_opts = {
+      var requestOpts = util.addAltAuthHeaders({
         method: 'get',
         path: [this.path, id].join('/'),
         query: query
-      };
+      }, altAuth);
 
-      if (alt_auth && alt_auth.token) {
-        request_opts.headers = {
-          'x-auth-token': alt_auth.token
-        };
-      } else if (alt_auth && alt_auth.api_key) {
-        request_opts.headers = {
-          'st2-api-key': alt_auth.api_key
-        };
-      }
-
-      return this.request(request_opts).then(function (res) {
+      return this.request(requestOpts).then(function (res) {
 
         if (res.statusCode >= 400) {
           throw {

--- a/lib/mixins/readable.js
+++ b/lib/mixins/readable.js
@@ -2,7 +2,7 @@
 
 var Readable = {
   get: {
-    value: function (id, query) {
+    value: function (id, query, alt_auth) {
       if (!id) {
         throw {
           name: 'ArgumentError',
@@ -10,11 +10,23 @@ var Readable = {
         };
       }
 
-      return this.request({
+      var request_opts = {
         method: 'get',
         path: [this.path, id].join('/'),
         query: query
-      }).then(function (res) {
+      };
+
+      if (alt_auth && alt_auth.token) {
+        request_opts.headers = {
+          'x-auth-token': alt_auth.token
+        };
+      } else if (alt_auth && alt_auth.api_key) {
+        request_opts.headers = {
+          'st2-api-key': alt_auth.api_key
+        };
+      }
+
+      return this.request(request_opts).then(function (res) {
 
         if (res.statusCode >= 400) {
           throw {

--- a/lib/mixins/repeatable.js
+++ b/lib/mixins/repeatable.js
@@ -1,8 +1,10 @@
 'use strict';
 
+var util = require('./util');
+
 var Repeatable = {
   repeat: {
-    value: function (id, payload, query, alt_auth) {
+    value: function (id, payload, query, altAuth) {
       if (!id) {
         throw {
           name: 'ArgumentError',
@@ -17,23 +19,13 @@ var Repeatable = {
         };
       }
 
-      var request_opts = {
+      var requestOpts = util.addAltAuthHeaders({
         method: 'post',
         path: [this.path, id, 're_run'].join('/'),
         query: query
-      };
+      }, altAuth);
 
-      if (alt_auth && alt_auth.token) {
-        request_opts.headers = {
-          'x-auth-token': alt_auth.token
-        };
-      } else if (alt_auth && alt_auth.api_key) {
-        request_opts.headers = {
-          'st2-api-key': alt_auth.api_key
-        };
-      }
-
-      return this.request(request_opts, payload).then(function (res) {
+      return this.request(requestOpts, payload).then(function (res) {
 
         if (res.statusCode !== 201) {
           throw {

--- a/lib/mixins/repeatable.js
+++ b/lib/mixins/repeatable.js
@@ -2,7 +2,7 @@
 
 var Repeatable = {
   repeat: {
-    value: function (id, payload, query) {
+    value: function (id, payload, query, alt_auth) {
       if (!id) {
         throw {
           name: 'ArgumentError',
@@ -17,11 +17,23 @@ var Repeatable = {
         };
       }
 
-      return this.request({
+      var request_opts = {
         method: 'post',
         path: [this.path, id, 're_run'].join('/'),
         query: query
-      }, payload).then(function (res) {
+      };
+
+      if (alt_auth && alt_auth.token) {
+        request_opts.headers = {
+          'x-auth-token': alt_auth.token
+        };
+      } else if (alt_auth && alt_auth.api_key) {
+        request_opts.headers = {
+          'st2-api-key': alt_auth.api_key
+        };
+      }
+
+      return this.request(request_opts, payload).then(function (res) {
 
         if (res.statusCode !== 201) {
           throw {

--- a/lib/mixins/schedulable.js
+++ b/lib/mixins/schedulable.js
@@ -2,11 +2,23 @@
 
 var Schedulable = {
   schedule: {
-    value: function (payload, query) {
-      return this.request({
+    value: function (payload, query, alt_auth) {
+      var request_opts = {
         method: 'post',
         query: query
-      }, payload)
+      };
+
+      if (alt_auth && alt_auth.token) {
+        request_opts.headers = {
+          'x-auth-token': alt_auth.token
+        };
+      } else if (alt_auth && alt_auth.api_key) {
+        request_opts.headers = {
+          'st2-api-key': alt_auth.api_key
+        };
+      }
+
+      return this.request(request_opts, payload)
         .then(function (res) {
           if (res.statusCode !== 202) {
             throw {

--- a/lib/mixins/schedulable.js
+++ b/lib/mixins/schedulable.js
@@ -1,24 +1,16 @@
 'use strict';
 
+var util = require('./util');
+
 var Schedulable = {
   schedule: {
-    value: function (payload, query, alt_auth) {
-      var request_opts = {
+    value: function (payload, query, altAuth) {
+      var requestOpts = util.addAltAuthHeaders({
         method: 'post',
         query: query
-      };
+      }, altAuth);
 
-      if (alt_auth && alt_auth.token) {
-        request_opts.headers = {
-          'x-auth-token': alt_auth.token
-        };
-      } else if (alt_auth && alt_auth.api_key) {
-        request_opts.headers = {
-          'st2-api-key': alt_auth.api_key
-        };
-      }
-
-      return this.request(request_opts, payload)
+      return this.request(requestOpts, payload)
         .then(function (res) {
           if (res.statusCode !== 202) {
             throw {

--- a/lib/mixins/util.js
+++ b/lib/mixins/util.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var _ = require('lodash');
+
+module.exports.addAltAuthHeaders = function (originalOpts, altAuth) {
+	var opts = _.clone(originalOpts);
+
+  if (altAuth && altAuth.token) {
+  	if (!opts.headers) {
+	    opts.headers = {
+	      'x-auth-token': altAuth.token
+	    };
+	  } else {
+	  	opts.headers['x-auth-token'] = altAuth.token;
+	  }
+  } else if (altAuth && altAuth.key) {
+  	if (!opts.headers) {
+	    opts.headers = {
+	      'st2-api-key': altAuth.key
+	    };
+	  } else {
+	  	opts.headers['x-auth-token'] = altAuth.key;
+	  }
+  }
+
+  return opts;
+};

--- a/lib/mixins/util.js
+++ b/lib/mixins/util.js
@@ -3,24 +3,24 @@
 var _ = require('lodash');
 
 module.exports.addAltAuthHeaders = function (originalOpts, altAuth) {
-	var opts = _.clone(originalOpts);
+  var opts = _.clone(originalOpts);
 
   if (altAuth && altAuth.token) {
-  	if (!opts.headers) {
-	    opts.headers = {
-	      'x-auth-token': altAuth.token
-	    };
-	  } else {
-	  	opts.headers['x-auth-token'] = altAuth.token;
-	  }
+    if (!opts.headers) {
+      opts.headers = {
+        'x-auth-token': altAuth.token
+      };
+    } else {
+      opts.headers['x-auth-token'] = altAuth.token;
+    }
   } else if (altAuth && altAuth.key) {
-  	if (!opts.headers) {
-	    opts.headers = {
-	      'st2-api-key': altAuth.key
-	    };
-	  } else {
-	  	opts.headers['x-auth-token'] = altAuth.key;
-	  }
+    if (!opts.headers) {
+      opts.headers = {
+        'st2-api-key': altAuth.key
+      };
+    } else {
+      opts.headers['x-auth-token'] = altAuth.key;
+    }
   }
 
   return opts;

--- a/lib/mixins/util.js
+++ b/lib/mixins/util.js
@@ -19,7 +19,7 @@ module.exports.addAltAuthHeaders = function (originalOpts, altAuth) {
         'st2-api-key': altAuth.key
       };
     } else {
-      opts.headers['x-auth-token'] = altAuth.key;
+      opts.headers['st2-api-key'] = altAuth.key;
     }
   }
 

--- a/lib/mixins/writable.js
+++ b/lib/mixins/writable.js
@@ -2,7 +2,7 @@
 
 var Writable = {
   create: {
-    value: function (payload) {
+    value: function (payload, alt_auth) {
       if (!payload) {
         throw {
           name: 'ArgumentError',
@@ -10,9 +10,21 @@ var Writable = {
         };
       }
 
-      return this.request({
+      var request_opts = {
         method: 'post'
-      }, payload).then(function (res) {
+      };
+
+      if (alt_auth && alt_auth.token) {
+        request_opts.headers = {
+          'x-auth-token': alt_auth.token
+        };
+      } else if (alt_auth && alt_auth.api_key) {
+        request_opts.headers = {
+          'st2-api-key': alt_auth.api_key
+        };
+      }
+
+      return this.request(request_opts, payload).then(function (res) {
 
         if (res.statusCode !== 201) {
           var err = {

--- a/lib/mixins/writable.js
+++ b/lib/mixins/writable.js
@@ -1,8 +1,10 @@
 'use strict';
 
+var util = require('./util');
+
 var Writable = {
   create: {
-    value: function (payload, alt_auth) {
+    value: function (payload, altAuth) {
       if (!payload) {
         throw {
           name: 'ArgumentError',
@@ -10,21 +12,11 @@ var Writable = {
         };
       }
 
-      var request_opts = {
+      var requestOpts = util.addAltAuthHeaders({
         method: 'post'
-      };
+      }, altAuth);
 
-      if (alt_auth && alt_auth.token) {
-        request_opts.headers = {
-          'x-auth-token': alt_auth.token
-        };
-      } else if (alt_auth && alt_auth.api_key) {
-        request_opts.headers = {
-          'st2-api-key': alt_auth.api_key
-        };
-      }
-
-      return this.request(request_opts, payload).then(function (res) {
+      return this.request(requestOpts, payload).then(function (res) {
 
         if (res.statusCode !== 201) {
           var err = {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,22 @@
   "description": "StackStorm ST2 API library",
   "main": "index.js",
   "scripts": {
-    "test": "node_modules/.bin/mocha tests/",
+    "test": "nyc mocha tests/",
     "prepublish": "node_modules/.bin/gulp"
+  },
+  "nyc": {
+    "temp-directory": "./coverage/.nyc_output",
+    "include": [
+      "index.js",
+      "lib"
+    ],
+    "exclude": [
+      "test"
+    ],
+    "reporter": [
+      "html",
+      "text"
+    ]
   },
   "author": "Kirill Izotov <enykeev@stackstorm.com>",
   "license": "Apache-2.0",
@@ -37,6 +51,7 @@
     "gulp-sourcemaps": "^1.6.0",
     "mocha": "^2.0.1",
     "nock": "^10.0.6",
+    "nyc": "^14.1.1",
     "promise-polyfill": "^2.1.0",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "gulp-size": "^2.0.0",
     "gulp-sourcemaps": "^1.6.0",
     "mocha": "^2.0.1",
-    "nock": "^0.50.0",
+    "nock": "^10.0.6",
     "promise-polyfill": "^2.1.0",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.0.0"

--- a/tests/test-attributable.js
+++ b/tests/test-attributable.js
@@ -57,7 +57,7 @@ describe('Attributable', function () {
         .matchHeader('st2-api-key', 'key-cccc')
         .reply(200, response);
 
-      var result = api.attribute(1, 'some', {api_key: 'key-cccc'});
+      var result = api.attribute(1, 'some', {key: 'key-cccc'});
 
       return result.then(function (response) {
         expect(mock.isDone()).to.be.true;

--- a/tests/test-attributable.js
+++ b/tests/test-attributable.js
@@ -36,6 +36,34 @@ describe('Attributable', function () {
       ]);
     });
 
+    it('should send an auth token', function () {
+      var response = {};
+
+      mock.get('/v1/test/1/attribute/some')
+        .matchHeader('x-auth-token', 'token-aaaa')
+        .reply(200, response);
+
+      var result = api.attribute(1, 'some', {token: 'token-aaaa'});
+
+      return result.then(function (response) {
+        expect(mock.isDone()).to.be.true;
+      });
+    });
+
+    it('should send an API key', function () {
+      var response = {};
+
+      mock.get('/v1/test/1/attribute/some')
+        .matchHeader('st2-api-key', 'key-cccc')
+        .reply(200, response);
+
+      var result = api.attribute(1, 'some', {api_key: 'key-cccc'});
+
+      return result.then(function (response) {
+        expect(mock.isDone()).to.be.true;
+      });
+    });
+
     it('should throw an error if no id is provided', function () {
       var fn = function () {
         api.attribute();

--- a/tests/test-deletable.js
+++ b/tests/test-deletable.js
@@ -57,7 +57,7 @@ describe('Deletable', function () {
         .matchHeader('st2-api-key', 'key-cccc')
         .reply(204, response);
 
-      var result = api.delete(1, {api_key: 'key-cccc'});
+      var result = api.delete(1, {key: 'key-cccc'});
 
       return result.then(function (response) {
         expect(mock.isDone()).to.be.true;

--- a/tests/test-deletable.js
+++ b/tests/test-deletable.js
@@ -36,6 +36,34 @@ describe('Deletable', function () {
       ]);
     });
 
+    it('should send an auth token', function () {
+      var response = {};
+
+      mock.delete('/v1/test/1')
+        .matchHeader('x-auth-token', 'token-aaaa')
+        .reply(204, response);
+
+      var result = api.delete(1, {token: 'token-aaaa'});
+
+      return result.then(function (response) {
+        expect(mock.isDone()).to.be.true;
+      });
+    });
+
+    it('should send an API key', function () {
+      var response = {};
+
+      mock.delete('/v1/test/1')
+        .matchHeader('st2-api-key', 'key-cccc')
+        .reply(204, response);
+
+      var result = api.delete(1, {api_key: 'key-cccc'});
+
+      return result.then(function (response) {
+        expect(mock.isDone()).to.be.true;
+      });
+    });
+
     it('should throw an error if no id is provided', function () {
       var fn = function () {
         api.delete();

--- a/tests/test-editable.js
+++ b/tests/test-editable.js
@@ -152,7 +152,7 @@ describe('Editable', function () {
         .matchHeader('st2-api-key', 'key-cccc')
         .reply(200, response);
 
-      var result = api.edit(ref, request, query, {api_key: 'key-cccc'});
+      var result = api.edit(ref, request, query, {key: 'key-cccc'});
 
       return result.then(function (response) {
         expect(mock.isDone()).to.be.true;

--- a/tests/test-editable.js
+++ b/tests/test-editable.js
@@ -111,6 +111,54 @@ describe('Editable', function () {
       ]);
     });
 
+    it('should send an auth token', function () {
+      var ref = 'some'
+        , request = {
+          id: '1'
+        }
+        , response = {
+          id: '1'
+        }
+        , query = {
+          a: 'b'
+        }
+        ;
+
+      mock.put('/v1/test/some?a=b', request)
+        .matchHeader('x-auth-token', 'token-aaaa')
+        .reply(200, response);
+
+      var result = api.edit(ref, request, query, {token: 'token-aaaa'});
+
+      return result.then(function (response) {
+        expect(mock.isDone()).to.be.true;
+      });
+    });
+
+    it('should send an API key', function () {
+      var ref = 'some'
+        , request = {
+          id: '1'
+        }
+        , response = {
+          id: '1'
+        }
+        , query = {
+          a: 'b'
+        }
+        ;
+
+      mock.put('/v1/test/some?a=b', request)
+        .matchHeader('st2-api-key', 'key-cccc')
+        .reply(200, response);
+
+      var result = api.edit(ref, request, query, {api_key: 'key-cccc'});
+
+      return result.then(function (response) {
+        expect(mock.isDone()).to.be.true;
+      });
+    });
+
     it('should throw an error if no payload is provided', function () {
       var fn = function () {
         api.edit();

--- a/tests/test-endpoint.js
+++ b/tests/test-endpoint.js
@@ -2,38 +2,155 @@
 'use strict';
 
 var expect = require('chai').expect
+  , EventEmitter = require('events')
+  , nock = require('nock')
   ;
 
 var endpoint = require('../lib/endpoint');
 
-describe('Endpoint factory', function () {
+describe('Endpoint', function () {
+  describe('#factory', function () {
 
-  it('should return an endpoint object', function () {
-    var mixin1 = {
-      a: {
-        value: 'a'
-      },
-      b: {
-        value: 'b'
-      }
-    };
+    it('should return an endpoint object', function () {
+      var mixin1 = {
+        a: {
+          value: 'a'
+        },
+        b: {
+          value: 'b'
+        }
+      };
 
-    var mixin2 = {
-      a: {
-        value: 'b'
-      },
-      c: {
-        value: 'd'
-      }
-    };
+      var mixin2 = {
+        a: {
+          value: 'b'
+        },
+        c: {
+          value: 'd'
+        }
+      };
 
-    var obj = endpoint('url', mixin1, mixin2);
+      var obj = endpoint('url', mixin1, mixin2);
 
-    expect(obj).to.be.an('object');
-    expect(obj.value).to.have.property('a', 'b');
-    expect(obj.value).to.have.property('b', 'b');
-    expect(obj.value).to.have.property('c', 'd');
-    expect(obj.value).to.have.property('path', 'url');
+      expect(obj).to.be.an('object');
+      expect(obj.value).to.have.property('a', 'b');
+      expect(obj.value).to.have.property('b', 'b');
+      expect(obj.value).to.have.property('c', 'd');
+      expect(obj.value).to.have.property('path', 'url');
+    });
   });
 
+  describe('#request', function () {
+
+    before(function () {
+      nock.disableNetConnect();
+      // Uncomment this and the nock.recorder.clear() lines for easier debugging
+      // nock.recorder.rec({
+      //   dont_print: true,
+      //   output_objects: true,
+      //   enable_reqheaders_recording: true
+      // });
+    });
+
+    after(function () {
+      nock.cleanAll();
+      // nock.recorder.clear();
+    });
+
+    beforeEach(function () {
+      nock.disableNetConnect();
+      nock.cleanAll();
+      // nock.recorder.clear();
+    });
+
+    it('should use the passed API token', function () {
+      var nock_mixin = {
+        protocol: {
+          enumerable: true,
+          value: 'http'
+        },
+        host: {
+          enumerable: true,
+          value: 'localhost'
+        },
+        port: {
+          enumerable: true,
+          value: '8080'
+        },
+        token: {
+          enumerable: true,
+          value: {}
+        },
+        key: {
+          enumerable: true,
+          value: {}
+        }
+      };
+      var test_endpoint_descriptor = Object.assign({}, endpoint('/test', nock_mixin), {enumerable: true});
+
+      var test_endpoint = Object.create({}, {test: test_endpoint_descriptor});
+
+      var scope = nock('http://localhost:8080')
+        .get('/test')
+        .matchHeader('x-auth-token', 'token-aaaa')
+        .reply(200, {});
+
+      var params = {
+        method: 'GET',
+        headers: {
+          'x-auth-token': 'token-aaaa'
+        }
+      };
+      return test_endpoint.test.request(params, {})
+        .then(function (response) {
+          expect(response.config.headers).to.be.an('object').and.to.have.property('x-auth-token');
+          expect(response.config.headers['x-auth-token']).to.equal('token-aaaa');
+        });
+    });
+
+    it('should use the passed API key', function () {
+      var nock_mixin = {
+        protocol: {
+          enumerable: true,
+          value: 'http'
+        },
+        host: {
+          enumerable: true,
+          value: 'localhost'
+        },
+        port: {
+          enumerable: true,
+          value: '8080'
+        },
+        token: {
+          enumerable: true,
+          value: {}
+        },
+        key: {
+          enumerable: true,
+          value: {}
+        }
+      };
+      var test_endpoint_descriptor = Object.assign({}, endpoint('/test', nock_mixin), {enumerable: true});
+
+      var test_endpoint = Object.create({}, {test: test_endpoint_descriptor});
+
+      var scope = nock('http://localhost:8080')
+        .get('/test')
+        .matchHeader('st2-api-key', 'key-cccc')
+        .reply(200, {});
+
+      var params = {
+        method: 'GET',
+        headers: {
+          'st2-api-key': 'key-cccc'
+        }
+      };
+      return test_endpoint.test.request(params, {})
+        .then(function (response) {
+          expect(response.config.headers).to.be.an('object').and.to.have.property('st2-api-key');
+          expect(response.config.headers['st2-api-key']).to.equal('key-cccc');
+        });
+    });
+  });
 });

--- a/tests/test-enumerable.js
+++ b/tests/test-enumerable.js
@@ -53,6 +53,36 @@ describe('Enumerable', function () {
       ]);
     });
 
+    it('should send an auth token', function () {
+      var response = []
+        ;
+
+      mock.get('/v1/test?a=b')
+        .matchHeader('x-auth-token', 'token-aaaa')
+        .reply(200, response);
+
+      var result = api.listAll({ a: 'b' }, {token: 'token-aaaa'});
+
+      return result.then(function (response) {
+        expect(mock.isDone()).to.be.true;
+      });
+    });
+
+    it('should send an API key', function () {
+      var response = []
+        ;
+
+      mock.get('/v1/test?a=b')
+        .matchHeader('st2-api-key', 'key-cccc')
+        .reply(200, response);
+
+      var result = api.listAll({ a: 'b' }, {api_key: 'key-cccc'});
+
+      return result.then(function (response) {
+        expect(mock.isDone()).to.be.true;
+      });
+    });
+
     it('should reject the promise if server returns 4xx or 5xx status code', function () {
       mock.get('/v1/test')
         .reply(400, 'some');

--- a/tests/test-enumerable.js
+++ b/tests/test-enumerable.js
@@ -76,7 +76,7 @@ describe('Enumerable', function () {
         .matchHeader('st2-api-key', 'key-cccc')
         .reply(200, response);
 
-      var result = api.listAll({ a: 'b' }, {api_key: 'key-cccc'});
+      var result = api.listAll({ a: 'b' }, {key: 'key-cccc'});
 
       return result.then(function (response) {
         expect(mock.isDone()).to.be.true;

--- a/tests/test-mixins-util.js
+++ b/tests/test-mixins-util.js
@@ -1,0 +1,61 @@
+/*global describe, it*/
+'use strict';
+
+var chai = require('chai');
+var util = require('../lib/mixins/util');
+
+var expect = chai.expect;
+
+describe('mixins/util', function () {
+  it('should update auth token header when it previously exists', function () {
+    var originalParams = {
+      headers: {
+        'x-auth-token': 'original-auth-token'
+      }
+    };
+    var newAuthToken = 'new-token';
+
+    var result = util.addAltAuthHeaders(originalParams, {token: newAuthToken});
+
+    expect(result).has.property('headers');
+    expect(result.headers).has.property('x-auth-token');
+    expect(result.headers['x-auth-token']).to.equal(newAuthToken);
+  });
+
+  it('should update API key header when it previously exists', function () {
+    var originalParams = {
+      headers: {
+        'st2-api-key': 'original-api-key'
+      }
+    };
+    var newApiKey = 'new-api-key';
+
+    var result = util.addAltAuthHeaders(originalParams, {key: newApiKey});
+
+    expect(result).has.property('headers');
+    expect(result.headers).has.property('st2-api-key');
+    expect(result.headers['st2-api-key']).to.equal(newApiKey);
+  });
+
+  it('should add auth token header when it doesn\'t exist', function () {
+    var originalParams = {};
+    var newAuthToken = 'added-token';
+
+    var result = util.addAltAuthHeaders(originalParams, {token: newAuthToken});
+
+    expect(result).has.property('headers');
+    expect(result.headers).has.property('x-auth-token');
+    expect(result.headers['x-auth-token']).to.equal(newAuthToken);
+  });
+
+  it('should add API key header when it doesn\'t exist', function () {
+    var originalParams = {};
+    var newApiKey = 'added-api-key';
+
+    var result = util.addAltAuthHeaders(originalParams, {key: newApiKey});
+
+    expect(result).has.property('headers');
+    expect(result.headers).has.property('st2-api-key');
+    expect(result.headers['st2-api-key']).to.equal(newApiKey);
+  });
+});

--- a/tests/test-paginatable.js
+++ b/tests/test-paginatable.js
@@ -141,6 +141,36 @@ describe('Paginatable', function () {
       ]);
     });
 
+    it('should send an auth token', function () {
+      var response = []
+        ;
+
+      mock.get('/v1/test?limit=100&a=b&offset=400')
+        .matchHeader('x-auth-token', 'token-aaaa')
+        .reply(200, response);
+
+      var result = api.listPage(5, { a: 'b', limit: 100 }, {token: 'token-aaaa'});
+
+      return result.then(function (response) {
+        expect(mock.isDone()).to.be.true;
+      });
+    });
+
+    it('should send an API key', function () {
+      var response = []
+        ;
+
+      mock.get('/v1/test?limit=100&a=b&offset=400')
+        .matchHeader('st2-api-key', 'key-cccc')
+        .reply(200, response);
+
+      var result = api.listPage(5, { a: 'b', limit: 100 }, {api_key: 'key-cccc'});
+
+      return result.then(function (response) {
+        expect(mock.isDone()).to.be.true;
+      });
+    });
+
   });
 
   describe('#list()', function () {

--- a/tests/test-paginatable.js
+++ b/tests/test-paginatable.js
@@ -164,7 +164,7 @@ describe('Paginatable', function () {
         .matchHeader('st2-api-key', 'key-cccc')
         .reply(200, response);
 
-      var result = api.listPage(5, { a: 'b', limit: 100 }, {api_key: 'key-cccc'});
+      var result = api.listPage(5, { a: 'b', limit: 100 }, {key: 'key-cccc'});
 
       return result.then(function (response) {
         expect(mock.isDone()).to.be.true;

--- a/tests/test-readable.js
+++ b/tests/test-readable.js
@@ -36,6 +36,34 @@ describe('Readable', function () {
       ]);
     });
 
+    it('should send an auth token', function () {
+      var response = {};
+
+      mock.get('/v1/test/1?a=b')
+        .matchHeader('x-auth-token', 'token-aaaa')
+        .reply(200, response);
+
+      var result = api.get(1, {a: 'b'}, {token: 'token-aaaa'});
+
+      result.then(function (response) {
+        expect(mock.isDone()).to.be.true;
+      });
+    });
+
+    it('should send an API key', function () {
+      var response = {};
+
+      mock.get('/v1/test/1?a=b')
+        .matchHeader('st2-api-key', 'key-cccc')
+        .reply(200, response);
+
+      var result = api.get(1, {a: 'b'}, {api_key: 'key-cccc'});
+
+      result.then(function (response) {
+        expect(mock.isDone()).to.be.true;
+      });
+    });
+
     it('should throw an error if no id is provided', function () {
       var fn = function () {
         api.get();

--- a/tests/test-readable.js
+++ b/tests/test-readable.js
@@ -57,7 +57,7 @@ describe('Readable', function () {
         .matchHeader('st2-api-key', 'key-cccc')
         .reply(200, response);
 
-      var result = api.get(1, {a: 'b'}, {api_key: 'key-cccc'});
+      var result = api.get(1, {a: 'b'}, {key: 'key-cccc'});
 
       result.then(function (response) {
         expect(mock.isDone()).to.be.true;

--- a/tests/test-repeatable.js
+++ b/tests/test-repeatable.js
@@ -43,6 +43,40 @@ describe('Repeatable', function () {
       ]);
     });
 
+    it('should send an auth token', function () {
+      var id = 'DEADBEEF'
+        , request = {}
+        , response = {}
+        ;
+
+      mock.post('/v1/test/' + id + '/re_run', request)
+        .matchHeader('x-auth-token', 'token-aaaa')
+        .reply(201, response);
+
+      var result = api.repeat(id, request, 'test', {token: 'token-aaaa'});
+
+      return result.then(function (response) {
+        expect(mock.isDone()).to.be.true;
+      });
+    });
+
+    it('should send an API key', function () {
+      var id = 'DEADBEEF'
+        , request = {}
+        , response = {}
+        ;
+
+      mock.post('/v1/test/' + id + '/re_run', request)
+        .matchHeader('st2-api-key', 'key-cccc')
+        .reply(201, response);
+
+      var result = api.repeat(id, request, 'test', {api_key: 'key-cccc'});
+
+      return result.then(function (response) {
+        expect(mock.isDone()).to.be.true;
+      });
+    });
+
     it('should throw an error if no id is provided', function () {
       var fn = function () {
         api.repeat();

--- a/tests/test-repeatable.js
+++ b/tests/test-repeatable.js
@@ -70,7 +70,7 @@ describe('Repeatable', function () {
         .matchHeader('st2-api-key', 'key-cccc')
         .reply(201, response);
 
-      var result = api.repeat(id, request, 'test', {api_key: 'key-cccc'});
+      var result = api.repeat(id, request, 'test', {key: 'key-cccc'});
 
       return result.then(function (response) {
         expect(mock.isDone()).to.be.true;

--- a/tests/test-schedulable.js
+++ b/tests/test-schedulable.js
@@ -1,0 +1,67 @@
+/*global describe, it*/
+'use strict';
+
+var chai = require('chai')
+  , chaiAsPromised = require("chai-as-promised")
+  , endpoint = require('../lib/endpoint')
+  , nock = require('nock')
+  , Opts = require('./opts')
+  ;
+
+chai.use(chaiAsPromised);
+nock.disableNetConnect();
+
+var expect = chai.expect
+  , Schedulable = require('../lib/mixins/schedulable')
+  , mock = nock('http://localhost', {
+    reqheaders: {
+      'content-type': 'application/json;charset=utf-8'
+    }
+  })
+  ;
+
+describe('Schedulable', function () {
+
+  var api = endpoint('/test', Opts, Schedulable).value;
+
+  describe('#schedule()', function () {
+
+    it('should return a promise of a single entity', function () {
+      var request = {}
+        , response = {}
+        ;
+
+      mock.post('/v1/test', request)
+        .reply(202, response);
+
+      var result = api.schedule({}, 'test');
+
+      return Promise.all([
+        expect(result).to.eventually.be.an('object'),
+        expect(result).to.eventually.be.deep.equal(response)
+      ]);
+    });
+
+    it('should reject the promise if server returns other than 202 status code', function () {
+      var request = {}
+        , response = 'accepted instead of scheduled'
+        ;
+
+      mock.post('/v1/test', request)
+        .reply(201, response);
+
+      var result = api.schedule({}, 'test');
+
+      return Promise.all([
+        expect(result).to.be.rejected,
+        result.catch(function (err) {
+          expect(err).to.have.property('name', 'APIError');
+          expect(err).to.have.property('status', 201);
+          expect(err).to.have.property('message', response);
+        })
+      ]);
+    });
+
+  });
+
+});

--- a/tests/test-schedulable.js
+++ b/tests/test-schedulable.js
@@ -42,6 +42,38 @@ describe('Schedulable', function () {
       ]);
     });
 
+    it('should send an auth token', function () {
+      var request = {}
+        , response = {}
+        ;
+
+      mock.post('/v1/test', request)
+        .matchHeader('x-auth-token', 'token-aaaa')
+        .reply(202, response);
+
+      var result = api.schedule({}, 'test', {token: 'token-aaaa'});
+
+      return result.then(function (response) {
+        expect(mock.isDone()).to.be.true;
+      });
+    });
+
+    it('should send an API key', function () {
+      var request = {}
+        , response = {}
+        ;
+
+      mock.post('/v1/test', request)
+        .matchHeader('st2-api-key', 'key-cccc')
+        .reply(202, response);
+
+      var result = api.schedule({}, 'test', {api_key: 'key-cccc'});
+
+      return result.then(function (response) {
+        expect(mock.isDone()).to.be.true;
+      });
+    });
+
     it('should reject the promise if server returns other than 202 status code', function () {
       var request = {}
         , response = 'accepted instead of scheduled'

--- a/tests/test-schedulable.js
+++ b/tests/test-schedulable.js
@@ -67,7 +67,7 @@ describe('Schedulable', function () {
         .matchHeader('st2-api-key', 'key-cccc')
         .reply(202, response);
 
-      var result = api.schedule({}, 'test', {api_key: 'key-cccc'});
+      var result = api.schedule({}, 'test', {key: 'key-cccc'});
 
       return result.then(function (response) {
         expect(mock.isDone()).to.be.true;

--- a/tests/test-writable.js
+++ b/tests/test-writable.js
@@ -67,7 +67,7 @@ describe('Writable', function () {
         .matchHeader('st2-api-key', 'key-cccc')
         .reply(201, response);
 
-      var result = api.create(request, {api_key: 'key-cccc'});
+      var result = api.create(request, {key: 'key-cccc'});
 
       return result.then(function (response) {
         expect(mock.isDone()).to.be.true;

--- a/tests/test-writable.js
+++ b/tests/test-writable.js
@@ -42,6 +42,38 @@ describe('Writable', function () {
       ]);
     });
 
+    it('should send an auth token', function () {
+      var request = {}
+        , response = {}
+        ;
+
+      mock.post('/v1/test', request)
+        .matchHeader('x-auth-token', 'token-aaaa')
+        .reply(201, response);
+
+      var result = api.create(request, {token: 'token-aaaa'});
+
+      return result.then(function (response) {
+        expect(mock.isDone()).to.be.true;
+      });
+    });
+
+    it('should send an API key', function () {
+      var request = {}
+        , response = {}
+        ;
+
+      mock.post('/v1/test', request)
+        .matchHeader('st2-api-key', 'key-cccc')
+        .reply(201, response);
+
+      var result = api.create(request, {api_key: 'key-cccc'});
+
+      return result.then(function (response) {
+        expect(mock.isDone()).to.be.true;
+      });
+    });
+
     it('should throw an error if no payload is provided', function () {
       var fn = function () {
         api.create();


### PR DESCRIPTION
This PR activates Travis tests for this repository. Travis is free (for this project) and easy to use, so it's easier to configure, extend, and fix when it breaks.

I added alternative authentication parameters for multiple mixins. This allows users to specify an object that contains a `token` or `key` key/value that overrides the client's stored authentication token/API key.

I also add tests for how to use auth tokens and API keys, add unrelated tests for the `Schedulable` mixin, and additional tests all around to test the alternative authentication parameters for all relevant mixins.

I updated the `nock` dependency to fix an issue where the nock mock was not properly matching requests based on a header value.

Coverage went from:

```
-------------------------|----------|----------|----------|----------|-------------------|
File                     |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
-------------------------|----------|----------|----------|----------|-------------------|
All files                |    86.16 |    81.62 |    81.67 |    86.16 |                   |
 st2client.js/lib        |    86.36 |       75 |      100 |    86.36 |                   |
  endpoint.js            |       95 |     87.5 |      100 |       95 |                23 |
 st2client.js/lib/mixins |    83.96 |    83.13 |     81.4 |    83.96 |                   |
  attributable.js        |      100 |     87.5 |      100 |      100 |                29 |
  authenticatable.js     |    93.75 |     87.5 |      100 |    93.75 |                 7 |
  deletable.js           |      100 |     87.5 |      100 |      100 |                22 |
  editable.js            |      100 |      100 |      100 |      100 |                   |
  enumerable.js          |      100 |      100 |      100 |      100 |                   |
  paginatable.js         |      100 |    94.12 |      100 |      100 |                 3 |
  readable.js            |      100 |    83.33 |      100 |      100 |                23 |
  repeatable.js          |      100 |      100 |      100 |      100 |                   |
  routable.js            |       80 |    83.33 |      100 |       80 |              7,16 |
  schedulable.js         |    33.33 |        0 |        0 |    33.33 |        6,11,12,19 |
  streamable.js          |       50 |    62.86 |       40 |       50 |... ,97,99,102,104 |
  watchable.js           |    96.43 |    93.75 |      100 |    96.43 |                42 |
  writable.js            |    90.91 |     87.5 |      100 |    90.91 |                25 |
-------------------------|----------|----------|----------|----------|-------------------|
```

to this:

```
-------------------------|----------|----------|----------|----------|-------------------|
File                     |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
-------------------------|----------|----------|----------|----------|-------------------|
All files                |    88.37 |    83.33 |    85.25 |    88.37 |                   |
 st2client.js/lib        |    85.48 |    70.83 |      100 |    85.48 |                   |
  endpoint.js            |    93.75 |       75 |      100 |    93.75 |                19 |
 st2client.js/lib/mixins |    88.02 |    86.63 |    86.36 |    88.02 |                   |
  attributable.js        |      100 |     87.5 |      100 |      100 |                33 |
  authenticatable.js     |    93.75 |     87.5 |      100 |    93.75 |                 7 |
  deletable.js           |      100 |     87.5 |      100 |      100 |                26 |
  editable.js            |      100 |      100 |      100 |      100 |                   |
  enumerable.js          |      100 |      100 |      100 |      100 |                   |
  paginatable.js         |      100 |    94.12 |      100 |      100 |                 3 |
  readable.js            |      100 |    83.33 |      100 |      100 |                27 |
  repeatable.js          |      100 |      100 |      100 |      100 |                   |
  routable.js            |       80 |    83.33 |      100 |       80 |              7,16 |
  schedulable.js         |      100 |      100 |      100 |      100 |                   |
  streamable.js          |       50 |    62.86 |       40 |       50 |... ,97,99,102,104 |
  util.js                |      100 |      100 |      100 |      100 |                   |
  watchable.js           |    96.43 |    93.75 |      100 |    96.43 |                42 |
  writable.js            |    92.31 |     87.5 |      100 |    92.31 |                29 |
-------------------------|----------|----------|----------|----------|-------------------|
```

(irrelevant coverage results have been truncated)