### PR TITLE
Bump axios from 0.7.0 to 0.19.0

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -53,6 +53,10 @@ var request = function (params, body) {
   return axios(config)
     .catch(function (err) {
       if (err instanceof Error) {
+        if (err.response) {
+          return err.response;
+        }
+
         throw new e.RequestError(err);
       }
       return err;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "st2client",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "StackStorm ST2 API library",
   "main": "index.js",
   "scripts": {
@@ -36,7 +36,7 @@
     "/lib"
   ],
   "dependencies": {
-    "axios": "^0.7.0",
+    "axios": "^0.19.0",
     "eventsource": "^0.1.4",
     "lodash": "^4.17.15",
     "object.assign": "^1.0.1"


### PR DESCRIPTION
Closes #75

When axios went from version 12 to 13 they changed error handling.

https://github.com/axios/axios/blob/master/UPGRADE_GUIDE.md#error-handling

Axios used to return a response object rather than an Error object. To maintain the test cases and maintain existing request handlers; I'm just pulling the response out of the Error object and passing it on. 