### PR TITLE
Update version to 1.2.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+1.2.4 - December 13, 2020
+-------------------------
+
+Updated
+~~~~~~~
+
+* Updated ``ini`` dependency to 1.3.8 (improvement) #82
+
 1.2.3 - April 23, 2020
 ----------------------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "st2client",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "st2client",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "StackStorm ST2 API library",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
PR #82 bumped the package version 1.2.3 in `package-lock.json`, but PR #76 bumped the version to 1.2.3 in `package.json`. NPM already had version 1.2.3, so we need to bump to version 1.2.4 in both `package.json` and `package-lock.json` to push the new version to NPM.